### PR TITLE
Update package.json to fix dist:min script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist": "npm-run-all -p dist:**",
     "dist:css": "shx cat css/*.css > dist/iD.css",
     "dist:mapillary": "shx mkdir -p dist/mapillary-js && shx cp -R node_modules/mapillary-js/dist/* dist/mapillary-js/",
-    "dist:min": "uglifyjs dist/iD.js -c 'warnings=false' -m -o dist/iD.min.js",
+    "dist:min": "uglifyjs dist/iD.js -c warnings=false -m -o dist/iD.min.js",
     "dist:svg:maki": "svg-sprite --symbol --symbol-dest . --symbol-sprite dist/img/maki-sprite.svg node_modules/@mapbox/maki/icons/*.svg",
     "dist:svg:id": "node svg/spriteify.js --svg svg/iD-sprite.src.svg --json svg/iD-sprite.json > dist/img/iD-sprite.svg",
     "imagery": "node data/update_imagery",


### PR DESCRIPTION
`npm install` was failing on Windows due to the single quotes added to `dist:min` in https://github.com/openstreetmap/iD/commit/bb9b4b87251dd4f28f358dc6ef543e4f43e11b73. Removing the single quotes makes it work install again successfully, and does not cause problems on OSX builds either.